### PR TITLE
Update method for getting old pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl https://get.docker.com/ | sh \
     python-dev \
     jq \
     wget \
-  && wget -nv https://bootstrap.pypa.io/get-pip.py \
+  && wget -nv https://bootstrap.pypa.io/2.6/get-pip.py \
   && python get-pip.py \
   \
   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ USER root
 
 RUN curl https://get.docker.com/ | sh \
   && usermod -aG docker jenkins \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
+  && apt update \
+  && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
     build-essential \
     libssl-dev \
     libffi-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl https://get.docker.com/ | sh \
   \
   && pip install -U setuptools==36.0.1 \
   && pip install \
-    ansible==2.6.4.0 \
+    ansible==2.10.3 \
   && rm -rf /var/lib/apt/lists/*
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM jenkins/jenkins:lts
 
-MAINTAINER victomartin@gmail.com
+LABEL MAINTAINER=victomartin@gmail.com
 
 USER root
 
 RUN curl https://get.docker.com/ | sh \
   && usermod -aG docker jenkins \
-  \
-  \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential \
@@ -18,8 +16,6 @@ RUN curl https://get.docker.com/ | sh \
     wget \
   && wget -nv https://bootstrap.pypa.io/2.6/get-pip.py \
   && python get-pip.py \
-  \
-  \
   && pip install -U setuptools==36.0.1 \
   && pip install \
     ansible==2.10.3 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Jenkins
 
-Docker Image based on official Jenkins image, but with docker added.
+This image adds both docker and ansible to the official LTS jenkins image.
+It is updated regularly.
 
 You can get it at https://hub.docker.com/r/korrd2/jenkins/
 
+For usage, refer to https://github.com/jenkinsci/docker#usage, as it is exactly the same as the official image.


### PR DESCRIPTION
This will ensure that we can still get old pip since python2 deprecation. Shame on you, Jenkins!