### PR TITLE
Stop using groovy interpolation to prevent leakage and injection

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -16,20 +16,20 @@ node {
       }
 
       stage("build") {
-        sh "docker build --pull -t '$IMAGE_TAG:$BUILD_NUMBER' ."
+        sh 'docker build --pull -t $IMAGE_TAG:$BUILD_NUMBER .'
       }
 
       stage("push") {
 
         if (env.BRANCH_NAME == "master") {
-          sh "docker tag '$IMAGE_TAG:$BUILD_NUMBER' '$IMAGE_TAG:lts'"
-          sh "docker push '$IMAGE_TAG:lts'"
+          sh 'docker tag $IMAGE_TAG:$BUILD_NUMBER $IMAGE_TAG:lts'
+          sh 'docker push $IMAGE_TAG:lts'
         } else {
 
           def SANITIZED_BRANCH_NAME = "${sanitizedBranchName(BRANCH_NAME)}"
 
-          sh "docker tag '$IMAGE_TAG:$BUILD_NUMBER' '$IMAGE_TAG:$SANITIZED_BRANCH_NAME'"
-          sh "docker push '$IMAGE_TAG:$SANITIZED_BRANCH_NAME'"
+          sh 'docker tag $IMAGE_TAG:$BUILD_NUMBER $IMAGE_TAG:$SANITIZED_BRANCH_NAME'
+          sh 'docker push $IMAGE_TAG:$SANITIZED_BRANCH_NAME'
         }
 
       }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -11,7 +11,7 @@ node {
         env.REPO = "Jenkins"
 
         withCredentials([usernamePassword(credentialsId: 'DOCKER', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-          sh "docker login -u='$DOCKER_USERNAME' -p='$DOCKER_PASSWORD'"
+          sh 'docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD'
         }
       }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ node {
           sh 'docker push $IMAGE_TAG:lts'
         } else {
 
-          def SANITIZED_BRANCH_NAME = "${sanitizedBranchName(BRANCH_NAME)}"
+          env.SANITIZED_BRANCH_NAME = "${sanitizedBranchName(BRANCH_NAME)}"
 
           sh 'docker tag $IMAGE_TAG:$BUILD_NUMBER $IMAGE_TAG:$SANITIZED_BRANCH_NAME'
           sh 'docker push $IMAGE_TAG:$SANITIZED_BRANCH_NAME'


### PR DESCRIPTION
Groovy's string interpolation can lead to credentials leakage: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation

Also, groovy interpolation inside shell commands can lead to shell injection: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#interpolation-of-sensitive-environment-variables